### PR TITLE
Add disable function

### DIFF
--- a/logger.js
+++ b/logger.js
@@ -7,6 +7,8 @@ const path = require('path')
 const moment = require('moment')
 const SysLogger = require('ain2')
 
+let LOGACIOUS_ENABLED = true
+
 Object.defineProperty(module, '__stack', {
   get: function () {
     var orig = Error.prepareStackTrace
@@ -74,6 +76,9 @@ function prepare (prependList, jsArguments) {
 
 function wrapWithMetadata (level, func) {
   return function () {
+    if (!LOGACIOUS_ENABLED){
+      return
+    }
     var args = prepare([
       '[' + level +']',
       moment().format('YYYY-MM-DD HH:mm:ss.SSS'),
@@ -115,14 +120,17 @@ const debug = wrapWithMetadata('DEBUG', logger.log)
 const info = wrapWithMetadata('INFO', logger.info)
 const warn = wrapWithMetadata('WARN', logger.warn)
 const error = wrapWithMetadata('ERROR', logger.error)
-
+const disable = () => {
+  LOGACIOUS_ENABLED = false
+}
 
 module.exports = () => ({
   name: 'global',
   debug,
   info,
   warn,
-  error
+  error,
+  disable,
 })
 /* $lab:coverage:on$ */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logacious",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "A node.js logger that outputs the filename and line number of where the logger is called",
   "main": "logger.js",
   "scripts": {


### PR DESCRIPTION
When running unit tests on code that is using logacious, it's nice to have a way to disable all logging.
This PR adds a disable() function that silences logacious. E.g. In a project using Jest, this function can be called in a setupFilesAfterEnv file.