### PR TITLE
Upgrade lodash & bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,48 @@
+{
+  "name": "logacious",
+  "version": "0.4.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ain2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ain2/-/ain2-2.0.0.tgz",
+      "integrity": "sha1-Vh0NoLzElxzoDbC04qJ8CDDJwpg=",
+      "requires": {
+        "unix-dgram": "0.2.3"
+      }
+    },
+    "bindings": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.1.1.tgz",
+      "integrity": "sha1-lR964BAwL/xQsmWxJAMgF+0r9vM=",
+      "optional": true
+    },
+    "lodash": {
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+    },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
+    "nan": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
+      "optional": true
+    },
+    "unix-dgram": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/unix-dgram/-/unix-dgram-0.2.3.tgz",
+      "integrity": "sha1-6rczDx8QQdSPnBedn0xamWyvzrU=",
+      "optional": true,
+      "requires": {
+        "bindings": "~1.1.1",
+        "nan": "~2.3.2"
+      }
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "logacious",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "logacious",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "A node.js logger that outputs the filename and line number of where the logger is called",
   "main": "logger.js",
   "scripts": {
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/Portchain/logacious#readme",
   "dependencies": {
     "ain2": "2.0.0",
-    "lodash": "4.17.11",
+    "lodash": "^4.17.20",
     "moment": "2.24.0"
   }
 }


### PR DESCRIPTION
This PR upgrades the current problematic version of `lodash` which fixes a known security issue. It also bumps the current package version.